### PR TITLE
Remove external API configuration from JSON

### DIFF
--- a/health/pdf-service/data-config/health-bill-payment.json
+++ b/health/pdf-service/data-config/health-bill-payment.json
@@ -373,21 +373,6 @@
                                 "format": "DD/MM/YYYY HH:mm:ss z"
                             }
                         ]
-                    },
-                    {
-                        "externalAPI": [
-                            {
-                                "path": "http://health-expense-calculator.health:8080/health-expense-calculator/v1/_searchMdms",
-                                "queryParam": "moduleName=tenant&masterName=tenants&tenantId=mz&filter=%5B?(@.code=='{$.tenantId}')%5D",
-                                "apiRequest": null,
-                                "responseMapping": [
-                                    {
-                                        "variable": "mdmsRes",
-                                        "value": "$.MdmsRes"
-                                    }
-                                ]
-                            }
-                        ]
                     }
                 ]
             }


### PR DESCRIPTION
Removed external API configuration related to health expense calculator.

https://github.com/egovernments/health-campaign-services/issues/1965