### PR TITLE
Add explicit DATE type mapping for taskDates in household member persister

### DIFF
--- a/health/egov-persister/analytics-persister/household-member-enriched-persister.yml
+++ b/health/egov-persister/analytics-persister/household-member-enriched-persister.yml
@@ -43,22 +43,33 @@ serviceMaps:
             - jsonPath: $.*.boundaryHierarchyCode.POSTADMINISTRATIVE
             - jsonPath: $.*.boundaryHierarchyCode.locality
             - jsonPath: $.*.boundaryHierarchyCode.village
+
             - jsonPath: $.*.dateOfBirth
+              type: DATE
+
             - jsonPath: $.*.age
             - jsonPath: $.*.gender
             - jsonPath: $.*.userName
             - jsonPath: $.*.nameOfUser
             - jsonPath: $.*.role
             - jsonPath: $.*.userAddress
+
             - jsonPath: $.*.taskDates
+              type: DATE
+
             - jsonPath: $.*.syncedDate
+              type: DATE
+
             - jsonPath: $.*.syncedTimeStamp
+
             - jsonPath: $.*.geoPoint[0]
             - jsonPath: $.*.geoPoint[1]
             - jsonPath: $.*.localityCode
+
             - jsonPath: $.*.additionalDetails
               type: JSON
               dbType: JSONB
+
             - jsonPath: $.*.projectId
             - jsonPath: $.*.projectType
             - jsonPath: $.*.projectTypeId


### PR DESCRIPTION
## Summary

This PR adds explicit `DATE` type mapping for the `taskDates` field in the household member persister configuration.

## Problem

The persister was binding `taskDates` as a `VARCHAR`, causing PostgreSQL to reject the insert