### PR TITLE
update task_dates mapping to JSONB to resolve persistor crash

### DIFF
--- a/health/egov-persister/analytics-persister/project-staff-enriched-persister.yml
+++ b/health/egov-persister/analytics-persister/project-staff-enriched-persister.yml
@@ -13,7 +13,7 @@ serviceMaps:
       transactionCodeJsonPath: $.id
       auditAttributeBasePath: $.*
       queryMaps:
-        - query: INSERT INTO analytics-test.project_staff_enriched(id, tenant_id, user_id, user_name, name_of_user, user_address, role, boundary_code, is_deleted, created_by, created_time, task_dates, additional_details, country_code, province_code, district_code, post_administrative_code, locality_code, village_code, project_id, project_type, project_type_id, project_name, campaign_number, campaign_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::date, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET user_id = EXCLUDED.user_id, user_name = EXCLUDED.user_name, name_of_user = EXCLUDED.name_of_user, user_address = EXCLUDED.user_address, role = EXCLUDED.role, boundary_code = EXCLUDED.boundary_code, is_deleted = EXCLUDED.is_deleted, task_dates = EXCLUDED.task_dates, additional_details = EXCLUDED.additional_details, country_code = EXCLUDED.country_code, province_code = EXCLUDED.province_code, district_code = EXCLUDED.district_code, post_administrative_code = EXCLUDED.post_administrative_code, locality_code = EXCLUDED.locality_code, village_code = EXCLUDED.village_code, project_id = EXCLUDED.project_id, project_type = EXCLUDED.project_type, project_type_id = EXCLUDED.project_type_id, project_name = EXCLUDED.project_name, campaign_number = EXCLUDED.campaign_number, campaign_id = EXCLUDED.campaign_id;
+        - query: INSERT INTO "analytics-test".project_staff_enriched(id, tenant_id, user_id, user_name, name_of_user, user_address, role, boundary_code, is_deleted, created_by, created_time, task_dates, additional_details, country_code, province_code, district_code, post_administrative_code, locality_code, village_code, project_id, project_type, project_type_id, project_name, campaign_number, campaign_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET user_id = EXCLUDED.user_id, user_name = EXCLUDED.user_name, name_of_user = EXCLUDED.name_of_user, user_address = EXCLUDED.user_address, role = EXCLUDED.role, boundary_code = EXCLUDED.boundary_code, is_deleted = EXCLUDED.is_deleted, task_dates = EXCLUDED.task_dates, additional_details = EXCLUDED.additional_details, country_code = EXCLUDED.country_code, province_code = EXCLUDED.province_code, district_code = EXCLUDED.district_code, post_administrative_code = EXCLUDED.post_administrative_code, locality_code = EXCLUDED.locality_code, village_code = EXCLUDED.village_code, project_id = EXCLUDED.project_id, project_type = EXCLUDED.project_type, project_type_id = EXCLUDED.project_type_id, project_name = EXCLUDED.project_name, campaign_number = EXCLUDED.campaign_number, campaign_id = EXCLUDED.campaign_id;
           basePath: $.*
           jsonMaps:
             - jsonPath: $.*.id
@@ -28,7 +28,8 @@ serviceMaps:
             - jsonPath: $.*.createdBy
             - jsonPath: $.*.createdTime
             - jsonPath: $.*.taskDates
-              dbType: STRING
+              type: JSON
+              dbType: JSONB
             - jsonPath: $.*.additionalDetails
               type: JSON
               dbType: JSONB


### PR DESCRIPTION
Changes Included:

Updated the SQL INSERT/UPDATE query to cast the task_dates parameter to ?::jsonb.

Modified the serviceMaps YAML configuration for taskDates to explicitly define type: JSON and dbType: JSONB.