### PR TITLE
feat: add studio egov-persister configs for individual/service-request

### DIFF
--- a/studio/egov-persister/individual-persister.yml
+++ b/studio/egov-persister/individual-persister.yml
@@ -1,0 +1,343 @@
+serviceMaps:
+  serviceName: individual
+  mappings:
+    - version: 1.0
+      description: Persists Individual
+      fromTopic: save-individual-studio-topic
+      isTransaction: true
+      isAuditEnabled: true
+      module: INDIVIDUAL
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.clientReferenceId
+      auditAttributeBasePath: $.*
+      queryMaps:
+        - query: INSERT INTO studio.address(id, clientReferenceId, tenantId, doorNo, latitude, longitude, locationAccuracy, type, addressLine1, addressLine2, landmark, city, pincode, buildingName, street, localityCode, wardCode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.*.address.*
+          jsonMaps:
+            - jsonPath: $.*.address.*.id
+            - jsonPath: $.*.address.*.clientReferenceId
+            - jsonPath: $.*.address.*.tenantId
+            - jsonPath: $.*.address.*.doorNo
+            - jsonPath: $.*.address.*.latitude
+            - jsonPath: $.*.address.*.longitude
+            - jsonPath: $.*.address.*.locationAccuracy
+            - jsonPath: $.*.address.*.type
+            - jsonPath: $.*.address.*.addressLine1
+            - jsonPath: $.*.address.*.addressLine2
+            - jsonPath: $.*.address.*.landmark
+            - jsonPath: $.*.address.*.city
+            - jsonPath: $.*.address.*.pincode
+            - jsonPath: $.*.address.*.buildingName
+            - jsonPath: $.*.address.*.street
+            - jsonPath: $.*.address.*.locality.code
+            - jsonPath: $.*.address.*.ward.code
+        - query: INSERT INTO studio.individual(id, userId, userUuid, clientReferenceId, tenantId, givenName, familyName, otherNames, dateOfBirth, gender, bloodGroup, mobileNumber, altContactNumber, email, fatherName, husbandName, photo, additionalDetails, createdBy, lastModifiedBy, createdTime, lastModifiedTime, rowVersion, isDeleted, individualId, relationship, isSystemUser, isSystemUserActive, username, type, roles, clientCreatedTime, clientLastModifiedTime, clientCreatedBy, clientLastModifiedBy) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.id
+            - jsonPath: $.*.userId
+            - jsonPath: $.*.userUuid
+            - jsonPath: $.*.clientReferenceId
+            - jsonPath: $.*.tenantId
+            - jsonPath: $.*.name.givenName
+            - jsonPath: $.*.name.familyName
+            - jsonPath: $.*.name.otherNames
+            - jsonPath: $.*.dateOfBirth
+              type: DATE
+            - jsonPath: $.*.gender
+            - jsonPath: $.*.bloodGroup
+            - jsonPath: $.*.mobileNumber
+            - jsonPath: $.*.altContactNumber
+            - jsonPath: $.*.email
+            - jsonPath: $.*.fatherName
+            - jsonPath: $.*.husbandName
+            - jsonPath: $.*.photo
+            - jsonPath: $.*.additionalFields
+              type: JSON
+              dbType: JSONB
+            - jsonPath: $.*.auditDetails.createdBy
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.createdTime
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.rowVersion
+            - jsonPath: $.*.isDeleted
+            - jsonPath: $.*.individualId
+            - jsonPath: $.*.relationship
+            - jsonPath: $.*.isSystemUser
+            - jsonPath: $.*.isSystemUserActive
+            - jsonPath: $.*.userDetails.username
+            - jsonPath: $.*.userDetails.type
+            - jsonPath: $.*.userDetails.roles
+              type: JSON
+              dbType: JSONB
+            - jsonPath: $.*.clientAuditDetails.createdTime
+            - jsonPath: $.*.clientAuditDetails.lastModifiedTime
+            - jsonPath: $.*.clientAuditDetails.createdBy
+            - jsonPath: $.*.clientAuditDetails.lastModifiedBy
+
+        - query: INSERT INTO studio.individual_address(individualId, addressId, type, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.*.address.*
+          jsonMaps:
+            - jsonPath: $.*.address.*.individualId
+            - jsonPath: $.*.address.*.id
+            - jsonPath: $.*.address.*.type
+            - jsonPath: $.*.address.*.auditDetails.createdBy
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.address.*.auditDetails.createdTime
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.address.*.isDeleted
+        - query: INSERT INTO studio.individual_identifier(id, clientReferenceId, individualClientReferenceId, identifierType, identifierId, individualId, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.*.identifiers.*
+          jsonMaps:
+            - jsonPath: $.*.identifiers.*.id
+            - jsonPath: $.*.identifiers.*.clientReferenceId
+            - jsonPath: $.*.clientReferenceId
+            - jsonPath: $.*.identifiers.*.identifierType
+            - jsonPath: $.*.identifiers.*.identifierId
+            - jsonPath: $.*.identifiers.*.individualId
+            - jsonPath: $.*.identifiers.*.auditDetails.createdBy
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.identifiers.*.auditDetails.createdTime
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.identifiers.*.isDeleted
+        - query: INSERT INTO studio.individual_skill(id, clientReferenceId, individualId, type, level, experience, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.*.skills.*
+          jsonMaps:
+            - jsonPath: $.*.skills.*.id
+            - jsonPath: $.*.skills.*.clientReferenceId
+            - jsonPath: $.*.skills.*.individualId
+            - jsonPath: $.*.skills.*.type
+            - jsonPath: $.*.skills.*.level
+            - jsonPath: $.*.skills.*.experience
+            - jsonPath: $.*.skills.*.auditDetails.createdBy
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.skills.*.auditDetails.createdTime
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.skills.*.isDeleted
+
+    - version: 1.0
+      description: Updates Individual
+      fromTopic: update-individual-studio-topic
+      isTransaction: true
+      isAuditEnabled: true
+      module: INDIVIDUAL
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.clientReferenceId
+      auditAttributeBasePath: $.*
+      queryMaps:
+        - query: UPDATE studio.individual SET userId=?, userUuid=?, tenantId=?, givenName=?, familyName=?, otherNames=?, dateOfBirth=?, Gender=?, bloodGroup=?, mobileNumber=?, altContactNumber=?, email=?, fatherName=?, husbandName=?, relationship=?, photo=?, isSystemUserActive=?, additionalDetails=?, lastModifiedBy=?, lastModifiedTime=?, rowVersion=?, username = ?, type = ?, roles = ?, clientLastModifiedTime = ?, clientLastModifiedBy = ? WHERE id=? AND isDeleted=false;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.userId
+            - jsonPath: $.*.userUuid
+            - jsonPath: $.*.tenantId
+            - jsonPath: $.*.name.givenName
+            - jsonPath: $.*.name.familyName
+            - jsonPath: $.*.name.otherNames
+            - jsonPath: $.*.dateOfBirth
+              type: DATE
+            - jsonPath: $.*.gender
+            - jsonPath: $.*.bloodGroup
+            - jsonPath: $.*.mobileNumber
+            - jsonPath: $.*.altContactNumber
+            - jsonPath: $.*.email
+            - jsonPath: $.*.fatherName
+            - jsonPath: $.*.husbandName
+            - jsonPath: $.*.relationship
+            - jsonPath: $.*.photo
+            - jsonPath: $.*.isSystemUserActive
+            - jsonPath: $.*.additionalFields
+              type: JSON
+              dbType: JSONB
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.rowVersion
+            - jsonPath: $.*.userDetails.username
+            - jsonPath: $.*.userDetails.type
+            - jsonPath: $.*.userDetails.roles
+              type: JSON
+              dbType: JSONB
+            - jsonPath: $.*.clientAuditDetails.lastModifiedTime
+            - jsonPath: $.*.clientAuditDetails.lastModifiedBy
+            - jsonPath: $.*.id
+        - query: INSERT INTO studio.address(id, clientReferenceId, tenantId, doorNo, latitude, longitude, locationAccuracy, type, addressLine1, addressLine2, landmark, city, pincode, buildingName, street, localityCode, wardCode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET doorno=?, latitude=?, longitude=?, locationaccuracy=?, type=?, addressline1=?, addressline2=?, landmark=?, city=?, pincode=?, buildingname=?, street=?, localitycode=?, wardCode=?;
+          basePath: $.*.address.*
+          jsonMaps:
+            - jsonPath: $.*.address.*.id
+            - jsonPath: $.*.address.*.clientReferenceId
+            - jsonPath: $.*.address.*.tenantId
+            - jsonPath: $.*.address.*.doorNo
+            - jsonPath: $.*.address.*.latitude
+            - jsonPath: $.*.address.*.longitude
+            - jsonPath: $.*.address.*.locationAccuracy
+            - jsonPath: $.*.address.*.type
+            - jsonPath: $.*.address.*.addressLine1
+            - jsonPath: $.*.address.*.addressLine2
+            - jsonPath: $.*.address.*.landmark
+            - jsonPath: $.*.address.*.city
+            - jsonPath: $.*.address.*.pincode
+            - jsonPath: $.*.address.*.buildingName
+            - jsonPath: $.*.address.*.street
+            - jsonPath: $.*.address.*.locality.code
+            - jsonPath: $.*.address.*.ward.code
+            - jsonPath: $.*.address.*.doorNo
+            - jsonPath: $.*.address.*.latitude
+            - jsonPath: $.*.address.*.longitude
+            - jsonPath: $.*.address.*.locationAccuracy
+            - jsonPath: $.*.address.*.type
+            - jsonPath: $.*.address.*.addressLine1
+            - jsonPath: $.*.address.*.addressLine2
+            - jsonPath: $.*.address.*.landmark
+            - jsonPath: $.*.address.*.city
+            - jsonPath: $.*.address.*.pincode
+            - jsonPath: $.*.address.*.buildingName
+            - jsonPath: $.*.address.*.street
+            - jsonPath: $.*.address.*.locality.code
+            - jsonPath: $.*.address.*.ward.code
+        - query: INSERT INTO studio.individual_address(individualId, addressId, type, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (individualId, addressId, type, isDeleted) WHERE isDeleted=false DO UPDATE SET lastModifiedBy = ?, lastModifiedTime = ?;
+          basePath: $.*.address.*
+          jsonMaps:
+            - jsonPath: $.*.address.*.individualId
+            - jsonPath: $.*.address.*.id
+            - jsonPath: $.*.address.*.type
+            - jsonPath: $.*.address.*.auditDetails.createdBy
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.address.*.auditDetails.createdTime
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.address.*.isDeleted
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedTime
+        - query: INSERT INTO studio.individual_identifier(id, clientReferenceId, individualClientReferenceId, individualId, identifierType, identifierId, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) WHERE isDeleted=false DO UPDATE SET identifierId = ?, identifierType = ?, lastModifiedBy = ?, lastModifiedTime = ?;
+          basePath: $.*.identifiers.*
+          jsonMaps:
+            - jsonPath: $.*.identifiers.*.id
+            - jsonPath: $.*.identifiers.*.clientReferenceId
+            - jsonPath: $.*.clientReferenceId
+            - jsonPath: $.*.identifiers.*.individualId
+            - jsonPath: $.*.identifiers.*.identifierType
+            - jsonPath: $.*.identifiers.*.identifierId
+            - jsonPath: $.*.identifiers.*.auditDetails.createdBy
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.identifiers.*.auditDetails.createdTime
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.identifiers.*.isDeleted
+            - jsonPath: $.*.identifiers.*.identifierId
+            - jsonPath: $.*.identifiers.*.identifierType
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedTime
+        - query: INSERT INTO studio.individual_skill(id, clientReferenceId, individualId, type, level, experience, createdBy, lastModifiedBy, createdTime, lastModifiedTime, isDeleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) WHERE isDeleted=false DO UPDATE SET type = ?, level = ?, experience = ?, lastModifiedBy = ?, lastModifiedTime = ?;
+          basePath: $.*.skills.*
+          jsonMaps:
+            - jsonPath: $.*.skills.*.id
+            - jsonPath: $.*.skills.*.clientReferenceId
+            - jsonPath: $.*.skills.*.individualId
+            - jsonPath: $.*.skills.*.type
+            - jsonPath: $.*.skills.*.level
+            - jsonPath: $.*.skills.*.experience
+            - jsonPath: $.*.skills.*.auditDetails.createdBy
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.skills.*.auditDetails.createdTime
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.skills.*.isDeleted
+            - jsonPath: $.*.skills.*.type
+            - jsonPath: $.*.skills.*.level
+            - jsonPath: $.*.skills.*.experience
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedTime
+
+    - version: 1.0
+      description: Deletes Individual and related Entities
+      fromTopic: delete-individual-studio-topic
+      isTransaction: true
+      isAuditEnabled: true
+      module: INDIVIDUAL
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.clientReferenceId
+      auditAttributeBasePath: $.*
+      queryMaps:
+        - query: UPDATE studio.individual SET lastModifiedBy=?, clientLastModifiedTime = ?, clientLastModifiedBy = ?,  lastModifiedTime=?, rowVersion=?, isDeleted=?, isSystemUserActive=? WHERE id=?;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.clientAuditDetails.lastModifiedTime
+            - jsonPath: $.*.clientAuditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.rowVersion
+            - jsonPath: $.*.isDeleted
+            - jsonPath: $.*.isSystemUserActive
+            - jsonPath: $.*.id
+        - query: UPDATE studio.individual_address SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=? WHERE individualId=? AND addressId=?;
+          basePath: $.*.address.*
+          jsonMaps:
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.address.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.address.*.isDeleted
+            - jsonPath: $.*.address.*.individualId
+            - jsonPath: $.*.address.*.id
+        - query: UPDATE studio.individual_identifier SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=? WHERE id=?;
+          basePath: $.*.identifiers.*
+          jsonMaps:
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.identifiers.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.identifiers.*.isDeleted
+            - jsonPath: $.*.identifiers.*.id
+        - query: UPDATE studio.individual_skill SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=? WHERE id=?;
+          basePath: $.*.skills.*
+          jsonMaps:
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.skills.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.skills.*.isDeleted
+            - jsonPath: $.*.skills.*.id
+        # Rescue sweeps for FULL individual deletes: the per-child updates above key on
+        # client-supplied sub-entity ids, which can be null (delete enrichment never assigns
+        # them and null-id sub-entities skip existence validation) or simply omitted from the
+        # payload — leaving active child rows pointing at a soft-deleted individual.
+        # Each sweep is scoped by the parent's individualId, touches only still-active rows,
+        # and is guarded by the PARENT's isDeleted bind (?=true): on sub-entity-only deletes
+        # (parent isDeleted=false) it is a guaranteed 0-row no-op, so it never over-deletes.
+        - query: UPDATE studio.individual_address SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=true WHERE individualId=? AND isDeleted=false AND ?=true;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.id
+            - jsonPath: $.*.isDeleted
+        - query: UPDATE studio.individual_identifier SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=true WHERE individualId=? AND isDeleted=false AND ?=true;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.id
+            - jsonPath: $.*.isDeleted
+        - query: UPDATE studio.individual_skill SET lastModifiedBy=?, lastModifiedTime=?, isDeleted=true WHERE individualId=? AND isDeleted=false AND ?=true;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.auditDetails.lastModifiedBy
+            - jsonPath: $.*.auditDetails.lastModifiedTime
+            - jsonPath: $.*.id
+            - jsonPath: $.*.isDeleted
+
+    - version: 1.0
+      description: Updates userId and userUuid received from user-service into an individual
+      fromTopic: update-user-id-studio-topic
+      isTransaction: true
+      isAuditEnabled: true
+      module: INDIVIDUAL
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.clientReferenceId
+      auditAttributeBasePath: $.*
+      queryMaps:
+        - query: UPDATE studio.individual SET userId=?, userUuid=? WHERE id=?;
+          basePath: $.*
+          jsonMaps:
+            - jsonPath: $.*.userId
+            - jsonPath: $.*.userUuid
+            - jsonPath: $.*.id

--- a/studio/egov-persister/service-request-persister.yml
+++ b/studio/egov-persister/service-request-persister.yml
@@ -1,0 +1,289 @@
+serviceMaps:
+  serviceName: service-request
+  mappings:
+    - version: 1.0
+      description: Persists service definition details in service definition table
+      fromTopic: save-service-definition-studio
+      isTransaction: true
+      isAuditEnabled: true
+      module: SERVICE-REQUEST
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.id
+      auditAttributeBasePath: $.*
+      queryMaps:
+
+        - query: INSERT INTO studio.eg_service_definition(id, tenantid, code, isactive, createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails, clientid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.ServiceDefinition
+          jsonMaps:
+            - jsonPath: $.ServiceDefinition.id
+
+            - jsonPath: $.ServiceDefinition.tenantId
+
+            - jsonPath: $.ServiceDefinition.code
+
+            - jsonPath: $.ServiceDefinition.isActive
+
+            - jsonPath: $.ServiceDefinition.auditDetails.createdBy
+
+            - jsonPath: $.ServiceDefinition.auditDetails.lastModifiedBy
+
+            - jsonPath: $.ServiceDefinition.auditDetails.createdTime
+
+            - jsonPath: $.ServiceDefinition.auditDetails.lastModifiedTime
+
+            - jsonPath: $.ServiceDefinition.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.ServiceDefinition.clientId
+
+
+        - query: INSERT INTO studio.eg_service_attribute_definition(id, referenceid, tenantid, code, datatype, "values", isactive, required, regex, "order", createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.ServiceDefinition.attributes.*
+          jsonMaps:
+            - jsonPath: $.ServiceDefinition.attributes.*.id
+
+            - jsonPath: $.ServiceDefinition.attributes.*.referenceId
+
+            - jsonPath: $.ServiceDefinition.attributes.*.tenantId
+
+            - jsonPath: $.ServiceDefinition.attributes.*.code
+
+            - jsonPath: $.ServiceDefinition.attributes.*.dataType
+
+            - jsonPath: $.ServiceDefinition.attributes.*.values
+              type: ARRAY
+              dbType: STRING
+
+            - jsonPath: $.ServiceDefinition.attributes.*.isActive
+
+            - jsonPath: $.ServiceDefinition.attributes.*.required
+
+            - jsonPath: $.ServiceDefinition.attributes.*.regex
+
+            - jsonPath: $.ServiceDefinition.attributes.*.order
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.createdBy
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.createdTime
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.ServiceDefinition.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB
+
+
+
+
+    - version: 1.0
+      description: Persists service details in service table
+      fromTopic: save-service-studio
+      isTransaction: true
+      isAuditEnabled: true
+      module: SERVICE-REQUEST
+      objecIdJsonPath: $.id
+      tenantIdJsonPath: $.tenantId
+      userUuidJsonPath: $.[0].auditDetails.createdBy
+      transactionCodeJsonPath: $.id
+      auditAttributeBasePath: $.*
+      queryMaps:
+
+
+        - query: INSERT INTO studio.eg_service(id, tenantid, servicedefid, referenceid, createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails, accountid, clientid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.Service
+          jsonMaps:
+            - jsonPath: $.Service.id
+
+            - jsonPath: $.Service.tenantId
+
+            - jsonPath: $.Service.serviceDefId
+
+            - jsonPath: $.Service.referenceId
+
+            - jsonPath: $.Service.auditDetails.createdBy
+
+            - jsonPath: $.Service.auditDetails.lastModifiedBy
+
+            - jsonPath: $.Service.auditDetails.createdTime
+
+            - jsonPath: $.Service.auditDetails.lastModifiedTime
+
+            - jsonPath: $.Service.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.accountId
+
+            - jsonPath: $.Service.clientId
+
+
+        - query: INSERT INTO studio.eg_service_attribute_value(id, referenceid, attributecode, value, createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+          basePath: $.Service.attributes.*
+          jsonMaps:
+            - jsonPath: $.Service.attributes.*.id
+
+            - jsonPath: $.Service.attributes.*.referenceId
+
+            - jsonPath: $.Service.attributes.*.attributeCode
+
+            - jsonPath: $.Service.attributes.*.value
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.attributes.*.auditDetails.createdBy
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.Service.attributes.*.auditDetails.createdTime
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.Service.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB
+
+
+    - version: 1.0
+      description: Update Service Definition
+      fromTopic: update-service-definition-studio
+      isTransaction: true
+      queryMaps:
+
+        - query: UPDATE studio.eg_service_definition SET lastmodifiedby = ?, lastmodifiedtime = ?, additionaldetails = ?, isactive = ? WHERE id = ?
+
+          basePath: $.ServiceDefinition
+          jsonMaps:
+            - jsonPath: $.ServiceDefinition.auditDetails.lastModifiedBy
+
+            - jsonPath: $.ServiceDefinition.auditDetails.lastModifiedTime
+
+            - jsonPath: $.ServiceDefinition.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.ServiceDefinition.isActive
+
+            - jsonPath: $.ServiceDefinition.id
+
+        - query: INSERT INTO studio.eg_service_attribute_definition(id, referenceid, tenantid, code, datatype, "values", isactive, required, regex, "order", createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET datatype=?, "values"=?, isactive=?, required=?, regex=?, "order"=?, lastmodifiedby=?, lastmodifiedtime=?, additionaldetails=?;
+          basePath: $.ServiceDefinition.attributes.*
+          jsonMaps:
+            - jsonPath: $.ServiceDefinition.attributes.*.id
+
+            - jsonPath: $.ServiceDefinition.attributes.*.referenceId
+
+            - jsonPath: $.ServiceDefinition.attributes.*.tenantId
+
+            - jsonPath: $.ServiceDefinition.attributes.*.code
+
+            - jsonPath: $.ServiceDefinition.attributes.*.dataType
+
+            - jsonPath: $.ServiceDefinition.attributes.*.values
+              type: ARRAY
+              dbType: STRING
+
+            - jsonPath: $.ServiceDefinition.attributes.*.isActive
+
+            - jsonPath: $.ServiceDefinition.attributes.*.required
+
+            - jsonPath: $.ServiceDefinition.attributes.*.regex
+
+            - jsonPath: $.ServiceDefinition.attributes.*.order
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.createdBy
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.createdTime
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.ServiceDefinition.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.ServiceDefinition.attributes.*.dataType
+
+            - jsonPath: $.ServiceDefinition.attributes.*.values
+              type: ARRAY
+              dbType: STRING
+
+            - jsonPath: $.ServiceDefinition.attributes.*.isActive
+
+            - jsonPath: $.ServiceDefinition.attributes.*.required
+
+            - jsonPath: $.ServiceDefinition.attributes.*.regex
+
+            - jsonPath: $.ServiceDefinition.attributes.*.order
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.ServiceDefinition.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.ServiceDefinition.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB
+
+
+    - version: 1.0
+      description: Update details in service table
+      fromTopic: update-service-studio
+      isTransaction: true
+      queryMaps:
+
+
+        - query: UPDATE studio.eg_service SET lastmodifiedby = ?, lastmodifiedtime = ?, additionaldetails = ? WHERE id = ?
+          basePath: $.Service
+          jsonMaps:
+            - jsonPath: $.Service.auditDetails.lastModifiedBy
+
+            - jsonPath: $.Service.auditDetails.lastModifiedTime
+
+            - jsonPath: $.Service.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.id
+
+
+        - query: INSERT INTO studio.eg_service_attribute_value(id, referenceid, attributecode, value, createdby, lastmodifiedby, createdtime, lastmodifiedtime, additionaldetails) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET "value"=?, lastmodifiedby=?, lastmodifiedtime=?, additionaldetails=?;
+          basePath: $.Service.attributes.*
+          jsonMaps:
+            - jsonPath: $.Service.attributes.*.id
+
+            - jsonPath: $.Service.attributes.*.referenceId
+
+            - jsonPath: $.Service.attributes.*.attributeCode
+
+            - jsonPath: $.Service.attributes.*.value
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.attributes.*.auditDetails.createdBy
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.Service.attributes.*.auditDetails.createdTime
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.Service.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.attributes.*.value
+              type: JSON
+              dbType: JSONB
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedBy
+
+            - jsonPath: $.Service.attributes.*.auditDetails.lastModifiedTime
+
+            - jsonPath: $.Service.attributes.*.additionalFields
+              type: JSON
+              dbType: JSONB


### PR DESCRIPTION
Mirrors health's schema-isolated pattern so studio's individual and service-request data lands in the studio Postgres schema instead of colliding with the generic public-schema pipeline. Field mappings verified against the actual deployed models (individual shares health's model via health-services-models; service-request checked against its own independent model + Flyway DDL).